### PR TITLE
Add PetKit T5 device support

### DIFF
--- a/app/Filament/Resources/DeviceResource.php
+++ b/app/Filament/Resources/DeviceResource.php
@@ -12,6 +12,7 @@ use App\Petkit\Devices\PetkitFreshElement3;
 use App\Petkit\Devices\PetkitFreshElementSolo;
 use App\Petkit\Devices\PetkitPuraMax;
 use App\Petkit\Devices\PetkitPurobotCrystal;
+use App\Petkit\Devices\PetkitT5;
 use App\Petkit\Devices\PetkitYumshareSolo;
 use App\Petkit\Devices\PetkitYumshareDual;
 use Filament\Actions\ActionGroup;
@@ -47,6 +48,7 @@ class DeviceResource extends Resource
                     'd4h' => PetkitYumshareSolo::deviceName(),
                     'd4sh' => PetkitYumshareDual::deviceName(),
                     't7' => PetkitPurobotCrystal::deviceName(),
+                    't5' => PetkitT5::deviceName(),
                 ])
                     ->columnSpan('half')->disabled(),
 
@@ -91,6 +93,7 @@ class DeviceResource extends Resource
                             'd4h' => PetkitYumshareSolo::deviceName(),
                             'd4sh' => PetkitYumshareDual::deviceName(),
                             't7' => PetkitPurobotCrystal::deviceName(),
+                            't5' => PetkitT5::deviceName(),
                         };
                     }),
                 Tables\Columns\TextColumn::make('name')->searchable(),

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -106,6 +106,7 @@ class Device extends Model
             'd4h' => new Devices\PetkitYumshareSolo($this),
             'd4sh' => new Devices\PetkitYumshareDual($this),
             't7' => new Devices\PetkitPurobotCrystal($this),
+            't5' => new Devices\PetkitT5($this),
         };
     }
 
@@ -119,6 +120,7 @@ class Device extends Model
             'd4h' => Devices\Configuration\PetkitYumshareSolo::fromDevice($this),
             'd4sh' => Devices\Configuration\PetkitYumshareDual::fromDevice($this),
             't7' => Devices\Configuration\PetkitPurobotCrystal::fromDevice($this),
+            't5' => Devices\Configuration\PetkitT5::fromDevice($this),
         };
     }
 
@@ -132,6 +134,7 @@ class Device extends Model
             'd4h' => new UI\PetkitYumshareSolo($this),
             'd4sh' => new UI\PetkitYumshareDual($this),
             't7' => new UI\PetkitPurobotCrystal($this),
+            't5' => new UI\PetkitT5($this),
         };
     }
 

--- a/app/Petkit/Devices/Configuration/PetkitT5.php
+++ b/app/Petkit/Devices/Configuration/PetkitT5.php
@@ -1,0 +1,1141 @@
+<?php
+
+namespace App\Petkit\Devices\Configuration;
+
+use App\DTOs\DeviceConfigurationDTO;
+use App\DTOs\MultiRangeDTO;
+use App\Homeassistant\BinarySensor;
+use App\Homeassistant\Button;
+use App\Homeassistant\HASwitch;
+use App\Homeassistant\Image;
+use App\Homeassistant\Interfaces\Snapshot;
+use App\Homeassistant\Interfaces\Video;
+use App\Homeassistant\Number;
+use App\Homeassistant\Sensor;
+use App\Models\BluetoothDevice;
+use App\Models\Device;
+use App\Petkit\Interfaces\HasCamera;
+use Illuminate\Support\Facades\Storage;
+use WendellAdriel\ValidatedDTO\Casting\ArrayCast;
+use WendellAdriel\ValidatedDTO\Casting\BooleanCast;
+use WendellAdriel\ValidatedDTO\Casting\DTOCast;
+use WendellAdriel\ValidatedDTO\Casting\IntegerCast;
+use WendellAdriel\ValidatedDTO\Casting\StringCast;
+
+/**
+ * Configuration for the PetKit T5 - a camera equipped self-cleaning litter box
+ * with an automatic deodorant spray unit.
+ *
+ * Field set reverse engineered from the on-device `ctrl_t5` firmware (MIPS) and its
+ * `app_conf` dump (`t5.conf`): every settings key below was confirmed present in both
+ * the local file parser (`app_config_load`) and/or the remote property_set dispatcher
+ * (`parse_recv_property_set_normal` / `parse_recv_property_set_algo_param`).
+ * Notable renames confirmed via matching struct store-offsets: `timestamp_enable` (file)
+ * is `timeDisplay` on the wire, and `night` shares its offset with the wire alias `infrared`.
+ *
+ * NOTE: the property names must match the device's setting keys exactly, since
+ * {@see \App\Petkit\Devices\PetkitT5::propertyChange()} diffs the stored `settings`
+ * array and forwards the changed keys straight to the device.
+ */
+class PetkitT5 extends DeviceConfigurationDTO implements ConfigurationInterface, Video, Snapshot, HasCamera
+{
+    public array $schedule;
+
+    // States
+    #[Sensor(
+        technicalName: 'ip_address',
+        name: 'IP Address',
+        icon: 'mdi:information-outline',
+        valueTemplate: '{{ value_json.states.ipAddress }}',
+        entityCategory: 'diagnostic'
+    )]
+    public string $ipAddress;
+
+    #[Sensor(
+        technicalName: 'device_status',
+        name: 'Device Status',
+        icon: 'mdi:information-outline',
+        valueTemplate: '{{ value_json.states.state }}',
+        entityCategory: 'diagnostic'
+    )]
+    public ?string $workingState;
+
+    #[Sensor(
+        technicalName: 'error',
+        name: 'Error',
+        icon: 'mdi:alert-circle',
+        valueTemplate: "{{ 'Ok' if value_json.states.error is none else value_json.states.error }}",
+        entityCategory: 'diagnostic'
+    )]
+    public ?string $error;
+
+    #[BinarySensor(
+        technicalName: 'move_detected',
+        name: 'Move Detected',
+        icon: 'mdi:cursor-move',
+        deviceClass: 'motion',
+        valueTemplate: '{{ value_json.states.moveDetected }}',
+        entityCategory: 'diagnostic',
+        payloadOn: '1',
+        payloadOff: '0'
+    )]
+    public bool $moveDetected;
+
+    #[BinarySensor(
+        technicalName: 'pet_detected',
+        name: 'Pet Detected',
+        icon: 'mdi:cat',
+        deviceClass: 'motion',
+        valueTemplate: '{{ value_json.states.petDetected }}',
+        entityCategory: 'diagnostic',
+        payloadOn: '1',
+        payloadOff: '0'
+    )]
+    public bool $petDetected;
+
+    #[BinarySensor(
+        technicalName: 'lightning',
+        name: 'Light',
+        icon: 'mdi:lightbulb',
+        deviceClass: 'light',
+        valueTemplate: '{{ value_json.states.lightning }}',
+        entityCategory: 'diagnostic',
+        payloadOn: '1',
+        payloadOff: '0'
+    )]
+    public bool $lightning;
+
+    #[Image(
+        technicalName: 'last_snapshot',
+        name: 'Snapshot',
+    )]
+    public ?string $lastSnapshot;
+
+    public ?string $stream;
+
+    // Device meta (kept for signup / device info payloads)
+    public bool $shareOpen;
+    public bool $multiConfig;
+    public bool $autoUpgrade;
+    public int $typeCode;
+    public int $serviceStatus;
+    public int $hertz;
+
+    // Display / camera settings
+    #[HASwitch(
+        technicalName: 'time_display',
+        name: 'Timestamp Display',
+        commandTopic: 'setting/set',
+        icon: 'mdi:toggle-switch',
+        valueTemplate: '{{ value_json.settings.timeDisplay }}',
+        commandTemplate: '{"timeDisplay":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $timeDisplay;
+
+    #[HASwitch(
+        technicalName: 'camera',
+        name: 'Camera Switch',
+        commandTopic: 'setting/set',
+        icon: 'mdi:camera',
+        valueTemplate: '{{ value_json.settings.camera }}',
+        commandTemplate: '{"camera":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $camera;
+
+    public MultiRangeDTO $cameraMultiRange;
+
+    #[HASwitch(
+        technicalName: 'microphone',
+        name: 'Microphone',
+        commandTopic: 'setting/set',
+        icon: 'mdi:microphone',
+        valueTemplate: '{{ value_json.settings.microphone }}',
+        commandTemplate: '{"microphone":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $microphone;
+
+    #[HASwitch(
+        technicalName: 'night',
+        name: 'Night Vision',
+        commandTopic: 'setting/set',
+        icon: 'mdi:moon-new',
+        valueTemplate: '{{ value_json.settings.night }}',
+        commandTemplate: '{"night":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $night;
+
+    #[HASwitch(
+        technicalName: 'camera_light',
+        name: 'Camera Light',
+        commandTopic: 'setting/set',
+        icon: 'mdi:track-light',
+        valueTemplate: '{{ value_json.settings.cameraLight }}',
+        commandTemplate: '{"cameraLight":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $cameraLight;
+
+    #[HASwitch(
+        technicalName: 'toilet_light',
+        name: 'Toilet Light',
+        commandTopic: 'setting/set',
+        icon: 'mdi:lightbulb',
+        valueTemplate: '{{ value_json.settings.toiletLight }}',
+        commandTemplate: '{"toiletLight":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $toiletLight;
+
+    public bool $preLive;
+
+    // Indicator lights - not in Localkit UI - not exposed to HA
+    public bool $lightMode;
+
+    public MultiRangeDTO $lightMultiRange;
+
+    #[HASwitch(
+        technicalName: 'light_assist',
+        name: 'Light Assist for Cleaning',
+        commandTopic: 'setting/set',
+        icon: 'mdi:lightbulb-auto',
+        valueTemplate: '{{ value_json.settings.lightAssist }}',
+        commandTemplate: '{"lightAssist":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $lightAssist;
+
+    public array $cameraRangeTable;
+
+    // Do not disturb / tone - not in Localkit UI - not exposed to HA
+    public bool $toneMode;
+
+    public MultiRangeDTO $toneMultiRange;
+
+    public bool $disturbMode;
+
+    public MultiRangeDTO $distrubMultiRange;
+
+    // Lock
+    #[HASwitch(
+        technicalName: 'manual_lock',
+        name: 'Child Lock',
+        commandTopic: 'setting/set',
+        icon: 'mdi:lock',
+        valueTemplate: '{{ value_json.settings.manualLock }}',
+        commandTemplate: '{"manualLock":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $manualLock;
+
+    #[HASwitch(
+        technicalName: 'click_ok_enable',
+        name: 'Confirm Click Sound',
+        commandTopic: 'setting/set',
+        icon: 'mdi:gesture-tap',
+        valueTemplate: '{{ value_json.settings.clickOkEnable }}',
+        commandTemplate: '{"clickOkEnable":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $clickOkEnable;
+
+    // Cleaning behaviour
+    #[HASwitch(
+        technicalName: 'auto_work',
+        name: 'Auto Cleaning',
+        commandTopic: 'setting/set',
+        icon: 'mdi:broom',
+        valueTemplate: '{{ value_json.settings.autoWork }}',
+        commandTemplate: '{"autoWork":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $autoWork;
+
+    public int $autoIntervalMin;
+    public int $fixedTimeClear;
+
+    #[HASwitch(
+        technicalName: 'avoid_repeat',
+        name: 'Avoid Repeated Cleaning',
+        commandTopic: 'setting/set',
+        icon: 'mdi:repeat',
+        valueTemplate: '{{ value_json.settings.avoidRepeat }}',
+        commandTemplate: '{"avoidRepeat":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $avoidRepeat;
+
+    // Not in Localkit UI - not exposed to HA
+    public bool $underweight;
+
+    #[HASwitch(
+        technicalName: 'kitten',
+        name: 'Kitten Protection',
+        commandTopic: 'setting/set',
+        icon: 'mdi:cat',
+        valueTemplate: '{{ value_json.settings.kitten }}',
+        commandTemplate: '{"kitten":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $kitten;
+
+    // Not in Localkit UI - not exposed to HA
+    public bool $bury;
+    public bool $deepClean;
+    public bool $downpos;
+
+    #[HASwitch(
+        technicalName: 'sand_saving',
+        name: 'Litter Saving',
+        commandTopic: 'setting/set',
+        icon: 'mdi:leaf',
+        valueTemplate: '{{ value_json.settings.sandSaving }}',
+        commandTemplate: '{"sandSaving":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $sandSaving;
+
+    #[HASwitch(
+        technicalName: 'tumbling',
+        name: 'Tumbling',
+        commandTopic: 'setting/set',
+        icon: 'mdi:rotate-3d-variant',
+        valueTemplate: '{{ value_json.settings.tumbling }}',
+        commandTemplate: '{"tumbling":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $tumbling;
+    public int $lightest;
+    public int $stillTime;
+
+    // Litter Type - not exposed to HA
+    public int $sandType;
+
+    // No weight sensor confirmed on this device - not exposed to HA
+    public int $unit;
+
+    // Toilet / spray (deodorant) settings
+    #[HASwitch(
+        technicalName: 'toilet_detection',
+        name: 'Toilet Video Recording',
+        commandTopic: 'setting/set',
+        icon: 'mdi:toilet',
+        valueTemplate: '{{ value_json.settings.toiletDetection }}',
+        commandTemplate: '{"toiletDetection":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $toiletDetection;
+
+    #[HASwitch(
+        technicalName: 'ph_detection',
+        name: 'Urine pH Detection',
+        commandTopic: 'setting/set',
+        icon: 'mdi:water',
+        valueTemplate: '{{ value_json.settings.phDetection }}',
+        commandTemplate: '{"phDetection":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $phDetection;
+
+    #[HASwitch(
+        technicalName: 'soft_mode',
+        name: 'Loose Stool Recognition',
+        commandTopic: 'setting/set',
+        icon: 'mdi:cog',
+        valueTemplate: '{{ value_json.settings.softMode }}',
+        commandTemplate: '{"softMode":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $softMode;
+
+    #[HASwitch(
+        technicalName: 'auto_spray',
+        name: 'Auto Deodorizing',
+        commandTopic: 'setting/set',
+        icon: 'mdi:spray',
+        valueTemplate: '{{ value_json.settings.autoSpray }}',
+        commandTemplate: '{"autoSpray":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $autoSpray;
+
+    #[HASwitch(
+        technicalName: 'deep_spray',
+        name: 'Deep Deodorizing',
+        commandTopic: 'setting/set',
+        icon: 'mdi:spray',
+        valueTemplate: '{{ value_json.settings.deepSpray }}',
+        commandTemplate: '{"deepSpray":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $deepSpray;
+
+    public int $fixedTimeSpray;
+
+    #[Number(
+        technicalName: 'spray_days',
+        name: 'Deodorant Refill Cycle',
+        commandTopic: 'setting/set',
+        icon: 'mdi:calendar-refresh',
+        unitOfMeasurement: 'd',
+        valueTemplate: '{{ value_json.settings.sprayDays }}',
+        commandTemplate: '{"sprayDays":{{ value }}}',
+        entityCategory: 'config',
+        min: 0,
+        max: 90,
+        step: 1
+    )]
+    public int $sprayDays;
+
+    // Firmware confirms this local `deodor_tip_en` key, but never reads it from the
+    // remote property_set dispatcher - not exposed to HA / not settable remotely.
+    public bool $deodorTipEn;
+
+    // Detection
+    #[HASwitch(
+        technicalName: 'move_detection',
+        name: 'Move Detection',
+        commandTopic: 'setting/set',
+        icon: 'mdi:eye-arrow-left-outline',
+        valueTemplate: '{{ value_json.settings.moveDetection }}',
+        commandTemplate: '{"moveDetection":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $moveDetection;
+
+    #[Number(
+        technicalName: 'move_sensitivity',
+        name: 'Move Sensitivity',
+        commandTopic: 'setting/set',
+        icon: 'mdi:speaker',
+        valueTemplate: '{{ value_json.settings.moveSensitivity }}',
+        commandTemplate: '{"moveSensitivity":{{ value }}}',
+        entityCategory: 'config',
+        min: 0,
+        max: 9,
+        step: 1
+    )]
+    public int $moveSensitivity;
+
+    #[HASwitch(
+        technicalName: 'pet_detection',
+        name: 'Pet Appearance Detection',
+        commandTopic: 'setting/set',
+        icon: 'mdi:cat',
+        valueTemplate: '{{ value_json.settings.petDetection }}',
+        commandTemplate: '{"petDetection":{{ value }}}',
+        payloadOn: true,
+        payloadOff: false,
+        stateOn: true,
+        stateOff: false,
+        entityCategory: 'config'
+    )]
+    public bool $petDetection;
+
+    #[Number(
+        technicalName: 'pet_sensitivity',
+        name: 'Pet Appearance Sensitivity',
+        commandTopic: 'setting/set',
+        icon: 'mdi:cat',
+        valueTemplate: '{{ value_json.settings.petSensitivity }}',
+        commandTemplate: '{"petSensitivity":{{ value }}}',
+        entityCategory: 'config',
+        min: 0,
+        max: 9,
+        step: 1
+    )]
+    public int $petSensitivity;
+
+    public int $detectInterval;
+    public array $detectMultiRange;
+
+    // Sound (no speaker confirmed on this device - not exposed to HA)
+    public bool $soundEnable;
+    public bool $systemSoundEnable;
+    public int $volume;
+    public int $selectedSound;
+    public bool $voice;
+
+    // Cloud upload - not exposed to HA
+    public bool $upload;
+
+    // Local-file-only per firmware (no wire/property_set xref) - not exposed to HA
+    public bool $logUpload;
+
+    public array $capacity;
+
+    // Actions
+    #[Button(
+        technicalName: 'action_snapshot',
+        name: 'Take Snapshot',
+        commandTopic: 'action/start',
+        icon: 'mdi:camera',
+        commandTemplate: '{"action": "snapshot"}',
+        availabilityTemplate: 'online',
+    )]
+    private $actionSnapshot = 1;
+
+    #[Button(
+        technicalName: 'action_cleaning_start',
+        name: 'Start Cleaning',
+        commandTopic: 'action/start',
+        icon: 'mdi:broom',
+        commandTemplate: '{"action": "start_cleaning"}',
+        availabilityTemplate: '{% if value_json.states.state == "IDLE" %}online{% else %}offline{% endif %}',
+    )]
+    private $actionCleaning = 1;
+
+    #[Button(
+        technicalName: 'action_deodorize',
+        name: 'Deodorize',
+        commandTopic: 'action/start',
+        icon: 'mdi:spray',
+        commandTemplate: '{"action": "deodorize"}',
+        availabilityTemplate: '{% if value_json.states.state == "IDLE" %}online{% else %}offline{% endif %}',
+    )]
+    private $actionDeodorize = 1;
+
+    #[Button(
+        technicalName: 'action_level',
+        name: 'Level',
+        commandTopic: 'action/start',
+        icon: 'mdi:format-horizontal-align-center',
+        commandTemplate: '{"action": "level"}',
+        availabilityTemplate: '{% if value_json.states.state == "IDLE" %}online{% else %}offline{% endif %}',
+    )]
+    private $actionLevel = 1;
+
+    #[Button(
+        technicalName: 'action_start_lightning',
+        name: 'Start Lightning',
+        commandTopic: 'action/start',
+        icon: 'mdi:lightbulb-on',
+        commandTemplate: '{"action": "start_lightning"}',
+        availabilityTemplate: 'online',
+    )]
+    private $actionStartLightning = 1;
+
+    #[Button(
+        technicalName: 'action_stop_lightning',
+        name: 'Stop Lightning',
+        commandTopic: 'action/start',
+        icon: 'mdi:lightbulb-off',
+        commandTemplate: '{"action": "stop_lightning"}',
+        availabilityTemplate: 'online',
+    )]
+    private $actionStopLightning = 1;
+
+    protected function rules(): array
+    {
+        return [
+            'schedule' => ['array'],
+
+            // States
+            'ipAddress' => ['string'],
+            'workingState' => ['nullable', 'string'],
+            'error' => ['nullable', 'string'],
+            'moveDetected' => ['bool'],
+            'petDetected' => ['bool'],
+            'lightning' => ['bool'],
+            'lastSnapshot' => ['nullable', 'string'],
+            'stream' => ['nullable', 'string'],
+
+            // Meta
+            'shareOpen' => ['bool'],
+            'multiConfig' => ['bool'],
+            'autoUpgrade' => ['bool'],
+            'typeCode' => ['integer'],
+            'serviceStatus' => ['integer'],
+            'hertz' => ['integer', 'min:50', 'max:60'],
+
+            // Display / camera
+            'timeDisplay' => ['bool'],
+            'camera' => ['bool'],
+            'cameraMultiRange' => ['array'],
+            'microphone' => ['bool'],
+            'night' => ['bool'],
+            'cameraLight' => ['bool'],
+            'toiletLight' => ['bool'],
+            'preLive' => ['bool'],
+
+            // Lights
+            'lightMode' => ['bool'],
+            'lightMultiRange' => ['array'],
+            'lightAssist' => ['bool'],
+            'cameraRangeTable' => ['array'],
+
+            // Do not disturb
+            'toneMode' => ['bool'],
+            'toneMultiRange' => ['array'],
+            'disturbMode' => ['bool'],
+            'distrubMultiRange' => ['array'],
+
+            // Lock
+            'manualLock' => ['bool'],
+            'clickOkEnable' => ['bool'],
+
+            // Cleaning
+            'autoWork' => ['bool'],
+            'autoIntervalMin' => ['integer', 'min:0'],
+            'fixedTimeClear' => ['integer', 'min:0'],
+            'avoidRepeat' => ['bool'],
+            'underweight' => ['bool'],
+            'kitten' => ['bool'],
+            'bury' => ['bool'],
+            'deepClean' => ['bool'],
+            'downpos' => ['bool'],
+            'sandSaving' => ['bool'],
+            'tumbling' => ['bool'],
+            'lightest' => ['integer', 'min:0'],
+            'stillTime' => ['integer', 'min:0'],
+            'sandType' => ['integer', 'in:0,1,2'],
+            'unit' => ['integer', 'in:0,1'],
+
+            // Toilet / spray
+            'toiletDetection' => ['bool'],
+            'phDetection' => ['bool'],
+            'softMode' => ['bool'],
+            'autoSpray' => ['bool'],
+            'deepSpray' => ['bool'],
+            'fixedTimeSpray' => ['integer', 'min:0'],
+            'sprayDays' => ['integer', 'min:0', 'max:90'],
+            'deodorTipEn' => ['bool'],
+
+            // Detection
+            'moveDetection' => ['bool'],
+            'moveSensitivity' => ['integer', 'min:0', 'max:9'],
+            'petDetection' => ['bool'],
+            'petSensitivity' => ['integer', 'min:0', 'max:9'],
+            'detectInterval' => ['integer', 'min:0'],
+            'detectMultiRange' => ['array'],
+
+            // Sound
+            'soundEnable' => ['bool'],
+            'systemSoundEnable' => ['bool'],
+            'volume' => ['integer', 'min:0', 'max:9'],
+            'selectedSound' => ['integer'],
+            'voice' => ['bool'],
+
+            'upload' => ['bool'],
+            'logUpload' => ['bool'],
+            'capacity' => ['array'],
+        ];
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'schedule' => [],
+
+            // States
+            'ipAddress' => '',
+            'workingState' => null,
+            'error' => null,
+            'moveDetected' => false,
+            'petDetected' => false,
+            'lightning' => false,
+            'lastSnapshot' => null,
+            'stream' => null,
+
+            // Meta
+            'shareOpen' => false,
+            'multiConfig' => true,
+            'autoUpgrade' => false,
+            'typeCode' => 0,
+            'serviceStatus' => 2,
+            'hertz' => 50,
+
+            // Display / camera
+            'timeDisplay' => true,
+            'camera' => true,
+            'cameraMultiRange' => [
+                'name' => 'cameraMultiRange',
+                'ranges' => [['from' => 0, 'till' => 1440]],
+            ],
+            'microphone' => true,
+            'night' => true,
+            'cameraLight' => true,
+            'toiletLight' => true,
+            'preLive' => true,
+
+            // Lights
+            'lightMode' => true,
+            'lightMultiRange' => [
+                'name' => 'lightMultiRange',
+                'ranges' => [['from' => 0, 'till' => 1440]],
+            ],
+            'lightAssist' => true,
+            'cameraRangeTable' => $this->defaultRangeTable(),
+
+            // Do not disturb
+            'toneMode' => false,
+            'toneMultiRange' => [
+                'name' => 'toneMultiRange',
+                'ranges' => [['from' => 1320, 'till' => 360]],
+            ],
+            'disturbMode' => false,
+            'distrubMultiRange' => [
+                'name' => 'distrubMultiRange',
+                'ranges' => [['from' => 35, 'till' => 515]],
+            ],
+
+            // Lock
+            'manualLock' => false,
+            'clickOkEnable' => true,
+
+            // Cleaning
+            'autoWork' => false,
+            'autoIntervalMin' => 0,
+            'fixedTimeClear' => 0,
+            'avoidRepeat' => true,
+            'underweight' => false,
+            'kitten' => false,
+            'bury' => true,
+            'deepClean' => true,
+            'downpos' => false,
+            'sandSaving' => true,
+            'tumbling' => false,
+            'lightest' => 1520,
+            'stillTime' => 120,
+            'sandType' => 1,
+            'unit' => 0,
+
+            // Toilet / spray
+            'toiletDetection' => true,
+            'phDetection' => false,
+            'softMode' => false,
+            'autoSpray' => false,
+            'deepSpray' => false,
+            'fixedTimeSpray' => 0,
+            'sprayDays' => 45,
+            'deodorTipEn' => true,
+
+            // Detection
+            'moveDetection' => false,
+            'moveSensitivity' => 0,
+            'petDetection' => true,
+            'petSensitivity' => 0,
+            'detectInterval' => 0,
+            'detectMultiRange' => [],
+
+            // Sound
+            'soundEnable' => true,
+            'systemSoundEnable' => true,
+            'volume' => 7,
+            'selectedSound' => -1,
+            'voice' => false,
+
+            'upload' => true,
+            'logUpload' => true,
+            'capacity' => [
+                ['name' => 'fullVideo'],
+                ['name' => 'eventImage'],
+                ['name' => 'highLight'],
+                ['name' => 'dynamicVideo'],
+            ],
+        ];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'schedule' => new ArrayCast(),
+
+            // States
+            'ipAddress' => new StringCast(),
+            'workingState' => new StringCast(),
+            'error' => new StringCast(),
+            'moveDetected' => new BooleanCast(),
+            'petDetected' => new BooleanCast(),
+            'lightning' => new BooleanCast(),
+            'lastSnapshot' => new StringCast(),
+            'stream' => new StringCast(),
+
+            // Meta
+            'shareOpen' => new BooleanCast(),
+            'multiConfig' => new BooleanCast(),
+            'autoUpgrade' => new BooleanCast(),
+            'typeCode' => new IntegerCast(),
+            'serviceStatus' => new IntegerCast(),
+            'hertz' => new IntegerCast(),
+
+            // Display / camera
+            'timeDisplay' => new BooleanCast(),
+            'camera' => new BooleanCast(),
+            'cameraMultiRange' => new DTOCast(MultiRangeDTO::class),
+            'microphone' => new BooleanCast(),
+            'night' => new BooleanCast(),
+            'cameraLight' => new BooleanCast(),
+            'toiletLight' => new BooleanCast(),
+            'preLive' => new BooleanCast(),
+
+            // Lights
+            'lightMode' => new BooleanCast(),
+            'lightMultiRange' => new DTOCast(MultiRangeDTO::class),
+            'lightAssist' => new BooleanCast(),
+            'cameraRangeTable' => new ArrayCast(),
+
+            // Do not disturb
+            'toneMode' => new BooleanCast(),
+            'toneMultiRange' => new DTOCast(MultiRangeDTO::class),
+            'disturbMode' => new BooleanCast(),
+            'distrubMultiRange' => new DTOCast(MultiRangeDTO::class),
+
+            // Lock
+            'manualLock' => new BooleanCast(),
+            'clickOkEnable' => new BooleanCast(),
+
+            // Cleaning
+            'autoWork' => new BooleanCast(),
+            'autoIntervalMin' => new IntegerCast(),
+            'fixedTimeClear' => new IntegerCast(),
+            'avoidRepeat' => new BooleanCast(),
+            'underweight' => new BooleanCast(),
+            'kitten' => new BooleanCast(),
+            'bury' => new BooleanCast(),
+            'deepClean' => new BooleanCast(),
+            'downpos' => new BooleanCast(),
+            'sandSaving' => new BooleanCast(),
+            'tumbling' => new BooleanCast(),
+            'lightest' => new IntegerCast(),
+            'stillTime' => new IntegerCast(),
+            'sandType' => new IntegerCast(),
+            'unit' => new IntegerCast(),
+
+            // Toilet / spray
+            'toiletDetection' => new BooleanCast(),
+            'phDetection' => new BooleanCast(),
+            'softMode' => new BooleanCast(),
+            'autoSpray' => new BooleanCast(),
+            'deepSpray' => new BooleanCast(),
+            'fixedTimeSpray' => new IntegerCast(),
+            'sprayDays' => new IntegerCast(),
+            'deodorTipEn' => new BooleanCast(),
+
+            // Detection
+            'moveDetection' => new BooleanCast(),
+            'moveSensitivity' => new IntegerCast(),
+            'petDetection' => new BooleanCast(),
+            'petSensitivity' => new IntegerCast(),
+            'detectInterval' => new IntegerCast(),
+            'detectMultiRange' => new ArrayCast(),
+
+            // Sound
+            'soundEnable' => new BooleanCast(),
+            'systemSoundEnable' => new BooleanCast(),
+            'volume' => new IntegerCast(),
+            'selectedSound' => new IntegerCast(),
+            'voice' => new BooleanCast(),
+
+            'upload' => new BooleanCast(),
+            'logUpload' => new BooleanCast(),
+            'capacity' => new ArrayCast(),
+        ];
+    }
+
+    private function defaultRangeTable(): array
+    {
+        return array_map(fn (int $wday) => ['wday' => $wday, 'rangeSub' => [0]], range(0, 6));
+    }
+
+    public static function fromDevice(Device|BluetoothDevice $device): self
+    {
+        $config = $device->configuration;
+        $data = [];
+
+        // Load states
+        $data['workingState'] = $device->working_state ?? null;
+        $data['error'] = $device->error ?? null;
+
+        if (isset($config['states'])) {
+            $states = $config['states'];
+            $data['ipAddress'] = $states['ipAddress'] ?? null;
+            $data['moveDetected'] = $states['moveDetected'] ?? null;
+            $data['petDetected'] = $states['petDetected'] ?? null;
+            $data['lightning'] = $states['lightning'] ?? null;
+            $data['lastSnapshot'] = $states['lastSnapshot'] ?? null;
+            $data['stream'] = $states['stream'] ?? null;
+        }
+
+        if (isset($config['settings'])) {
+            $settings = $config['settings'];
+
+            // Meta
+            $data['shareOpen'] = $settings['shareOpen'] ?? null;
+            $data['multiConfig'] = $settings['multiConfig'] ?? null;
+            $data['autoUpgrade'] = $settings['autoUpgrade'] ?? null;
+            $data['typeCode'] = $settings['typeCode'] ?? null;
+            $data['serviceStatus'] = $settings['serviceStatus'] ?? null;
+            $data['hertz'] = $settings['hertz'] ?? null;
+
+            // Display / camera
+            $data['timeDisplay'] = $settings['timeDisplay'] ?? null;
+            $data['camera'] = $settings['camera'] ?? null;
+            $data['cameraMultiRange'] = $settings['cameraMultiRange'] ?? null;
+            $data['microphone'] = $settings['microphone'] ?? null;
+            $data['night'] = $settings['night'] ?? null;
+            $data['cameraLight'] = $settings['cameraLight'] ?? null;
+            $data['toiletLight'] = $settings['toiletLight'] ?? null;
+            $data['preLive'] = $settings['preLive'] ?? null;
+
+            // Lights
+            $data['lightMode'] = $settings['lightMode'] ?? null;
+            $data['lightMultiRange'] = $settings['lightMultiRange'] ?? null;
+            $data['lightAssist'] = $settings['lightAssist'] ?? null;
+            $data['cameraRangeTable'] = $settings['cameraRangeTable'] ?? null;
+
+            // Do not disturb
+            $data['toneMode'] = $settings['toneMode'] ?? null;
+            $data['toneMultiRange'] = $settings['toneMultiRange'] ?? null;
+            $data['disturbMode'] = $settings['disturbMode'] ?? null;
+            $data['distrubMultiRange'] = $settings['distrubMultiRange'] ?? null;
+
+            // Lock
+            $data['manualLock'] = $settings['manualLock'] ?? null;
+            $data['clickOkEnable'] = $settings['clickOkEnable'] ?? null;
+
+            // Cleaning
+            $data['autoWork'] = $settings['autoWork'] ?? null;
+            $data['autoIntervalMin'] = $settings['autoIntervalMin'] ?? null;
+            $data['fixedTimeClear'] = $settings['fixedTimeClear'] ?? null;
+            $data['avoidRepeat'] = $settings['avoidRepeat'] ?? null;
+            $data['underweight'] = $settings['underweight'] ?? null;
+            $data['kitten'] = $settings['kitten'] ?? null;
+            $data['bury'] = $settings['bury'] ?? null;
+            $data['deepClean'] = $settings['deepClean'] ?? null;
+            $data['downpos'] = $settings['downpos'] ?? null;
+            $data['sandSaving'] = $settings['sandSaving'] ?? null;
+            $data['tumbling'] = $settings['tumbling'] ?? null;
+            $data['lightest'] = $settings['lightest'] ?? null;
+            $data['stillTime'] = $settings['stillTime'] ?? null;
+            $data['sandType'] = $settings['sandType'] ?? null;
+            $data['unit'] = $settings['unit'] ?? null;
+
+            // Toilet / spray
+            $data['toiletDetection'] = $settings['toiletDetection'] ?? null;
+            $data['phDetection'] = $settings['phDetection'] ?? null;
+            $data['softMode'] = $settings['softMode'] ?? null;
+            $data['autoSpray'] = $settings['autoSpray'] ?? null;
+            $data['deepSpray'] = $settings['deepSpray'] ?? null;
+            $data['fixedTimeSpray'] = $settings['fixedTimeSpray'] ?? null;
+            $data['sprayDays'] = $settings['sprayDays'] ?? null;
+            $data['deodorTipEn'] = $settings['deodorTipEn'] ?? null;
+
+            // Detection
+            $data['moveDetection'] = $settings['moveDetection'] ?? null;
+            $data['moveSensitivity'] = $settings['moveSensitivity'] ?? null;
+            $data['petDetection'] = $settings['petDetection'] ?? null;
+            $data['petSensitivity'] = $settings['petSensitivity'] ?? null;
+            $data['detectInterval'] = $settings['detectInterval'] ?? null;
+            $data['detectMultiRange'] = $settings['detectMultiRange'] ?? null;
+
+            // Sound
+            $data['soundEnable'] = $settings['soundEnable'] ?? null;
+            $data['systemSoundEnable'] = $settings['systemSoundEnable'] ?? null;
+            $data['volume'] = $settings['volume'] ?? null;
+            $data['selectedSound'] = $settings['selectedSound'] ?? null;
+            $data['voice'] = $settings['voice'] ?? null;
+
+            $data['upload'] = $settings['upload'] ?? null;
+            $data['logUpload'] = $settings['logUpload'] ?? null;
+        }
+
+        // Load schedule and capacity
+        $data['schedule'] = $config['schedule'] ?? null;
+        $data['capacity'] = $config['capacity'] ?? null;
+
+        // detectMultiRange is a legitimate empty array; keep it if present
+        $filtered = array_filter($data, fn ($value) => $value !== null);
+
+        return new self($filtered);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'states' => [
+                'state' => $this->workingState,
+                'error' => $this->error,
+                'ipAddress' => $this->ipAddress,
+                'lastSnapshot' => $this->lastSnapshot,
+                'stream' => $this->stream,
+                'moveDetected' => $this->moveDetected,
+                'petDetected' => $this->petDetected,
+                'lightning' => $this->lightning,
+            ],
+            'settings' => [
+                // Meta
+                'shareOpen' => $this->shareOpen,
+                'multiConfig' => $this->multiConfig,
+                'autoUpgrade' => $this->autoUpgrade,
+                'typeCode' => $this->typeCode,
+                'serviceStatus' => $this->serviceStatus,
+                'hertz' => $this->hertz,
+
+                // Display / camera
+                'timeDisplay' => $this->timeDisplay,
+                'camera' => $this->camera,
+                'cameraMultiRange' => $this->cameraMultiRange,
+                'microphone' => $this->microphone,
+                'night' => $this->night,
+                'cameraLight' => $this->cameraLight,
+                'toiletLight' => $this->toiletLight,
+                'preLive' => $this->preLive,
+
+                // Lights
+                'lightMode' => $this->lightMode,
+                'lightMultiRange' => $this->lightMultiRange,
+                'lightAssist' => $this->lightAssist,
+                'cameraRangeTable' => $this->cameraRangeTable,
+
+                // Do not disturb
+                'toneMode' => $this->toneMode,
+                'toneMultiRange' => $this->toneMultiRange,
+                'disturbMode' => $this->disturbMode,
+                'distrubMultiRange' => $this->distrubMultiRange,
+
+                // Lock
+                'manualLock' => $this->manualLock,
+                'clickOkEnable' => $this->clickOkEnable,
+
+                // Cleaning
+                'autoWork' => $this->autoWork,
+                'autoIntervalMin' => $this->autoIntervalMin,
+                'fixedTimeClear' => $this->fixedTimeClear,
+                'avoidRepeat' => $this->avoidRepeat,
+                'underweight' => $this->underweight,
+                'kitten' => $this->kitten,
+                'bury' => $this->bury,
+                'deepClean' => $this->deepClean,
+                'downpos' => $this->downpos,
+                'sandSaving' => $this->sandSaving,
+                'tumbling' => $this->tumbling,
+                'lightest' => $this->lightest,
+                'stillTime' => $this->stillTime,
+                'sandType' => $this->sandType,
+                'unit' => $this->unit,
+
+                // Toilet / spray
+                'toiletDetection' => $this->toiletDetection,
+                'phDetection' => $this->phDetection,
+                'softMode' => $this->softMode,
+                'autoSpray' => $this->autoSpray,
+                'deepSpray' => $this->deepSpray,
+                'fixedTimeSpray' => $this->fixedTimeSpray,
+                'sprayDays' => $this->sprayDays,
+                'deodorTipEn' => $this->deodorTipEn,
+
+                // Detection
+                'moveDetection' => $this->moveDetection,
+                'moveSensitivity' => $this->moveSensitivity,
+                'petDetection' => $this->petDetection,
+                'petSensitivity' => $this->petSensitivity,
+                'detectInterval' => $this->detectInterval,
+                'detectMultiRange' => $this->detectMultiRange,
+
+                // Sound
+                'soundEnable' => $this->soundEnable,
+                'systemSoundEnable' => $this->systemSoundEnable,
+                'volume' => $this->volume,
+                'selectedSound' => $this->selectedSound,
+                'voice' => $this->voice,
+
+                'upload' => $this->upload,
+                'logUpload' => $this->logUpload,
+            ],
+            'schedule' => $this->schedule,
+            'capacity' => $this->capacity,
+        ];
+    }
+
+    public function toSnapshot(): ?string
+    {
+        if (is_null($this->lastSnapshot)) {
+            return null;
+        }
+        return base64_encode(Storage::disk('snapshots')->get($this->lastSnapshot));
+    }
+}

--- a/app/Petkit/Devices/PetkitT5.php
+++ b/app/Petkit/Devices/PetkitT5.php
@@ -1,0 +1,554 @@
+<?php
+
+namespace App\Petkit\Devices;
+
+use App\DTOs\PetkitDTOInterface;
+use App\Helpers\JsonHelper;
+use App\Helpers\Time;
+use App\Homeassistant\HomeassistantTopic;
+use App\Homeassistant\Interfaces\Snapshot;
+use App\Jobs\ServiceConnect;
+use App\Jobs\ServiceEnd;
+use App\Jobs\ServiceStart;
+use App\Jobs\SetProperty;
+use App\Jobs\TakeSnapshot;
+use App\Models\BluetoothDevice;
+use App\Models\Device;
+use App\MQTT\GenericReply;
+use App\Petkit\BluetoothDevices\BluetoothProxyInterface;
+use App\Petkit\BluetoothDevices\Message;
+use App\Petkit\DeviceActions;
+use App\Petkit\DeviceDefinition;
+use App\Petkit\Devices\Configuration\ConfigurationInterface;
+use App\Petkit\DeviceStates;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use PhpMqtt\Client\Facades\MQTT;
+
+/**
+ * The T5's `ctrl_t5` firmware (MIPS) confirms the same `_action` command vocabulary
+ * (start/stop/end/reset_pet/lapse/power/update/connect/privacy) and the same
+ * schedule/capacity local-file layout as the T7 (PuroBot Crystal), so the MQTT topic
+ * and action-dispatch plumbing below mirrors {@see PetkitPurobotCrystal} - only the
+ * settings schema (see Configuration\PetkitT5) differs and was verified independently.
+ * The numeric ServiceStart/ServiceEnd sub-action codes are inherited from that same
+ * family and were not independently re-verified against ctrl_t5's dispatcher.
+ */
+class PetkitT5 implements DeviceDefinition, Snapshot, BluetoothProxyInterface
+{
+    public static $workingStates = [
+        DeviceStates::CLEANING, DeviceStates::IDLE, DeviceStates::PET_IN,
+    ];
+    protected array $actions = [
+        DeviceActions::START_CLEAN, DeviceActions::DEODORIZE, DeviceActions::LEVEL, DeviceActions::TAKE_SNAPSHOT,
+        DeviceActions::RESET_WORKING_STATE, DeviceActions::START_LIGHTNING, DeviceActions::STOP_LIGHTNING,
+    ];
+
+    public function __construct(protected Device $device)
+    {
+
+    }
+
+    public function subscribedTopics(): array
+    {
+        return [
+            sprintf('/ota/device/upgrade/%s/%s', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/service/property/set', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/service/connect', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/service/ble', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/event/ble_relay_start/post_reply', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/event/ble_relay_over/post_reply', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/event/ble_response/post_reply', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/service/start', $this->device->productKey(), $this->device->deviceName()),
+            sprintf('/sys/%s/%s/thing/service/end', $this->device->productKey(), $this->device->deviceName()),
+        ];
+    }
+
+    public static function deviceName()
+    {
+        return 'T5';
+    }
+
+    public function stateTopics(): array
+    {
+        return [
+            sprintf('/sys/%s/%s/thing/event/ble_response/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+                $content = json_decode($message?->params?->content, false);
+                Message::handleProxyMessage($content);
+
+                $this->reply($topic, $message);
+            },
+            sprintf('/sys/%s/%s/thing/event/property/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+                // Presence of `workState` means cleaning is in progress - same convention as the T7.
+                $state = $message?->params;
+
+                $device->update([
+                    'working_state' => isset($state->workState) ? DeviceStates::CLEANING->value : DeviceStates::IDLE->value,
+                    'error' => $this->prepareErrorReporting($state),
+                    'configuration' => $this->updateConfiguration($state)
+                ]);
+            },
+            sprintf('/sys/%s/%s/thing/event/move_detect/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+
+                $state = json_decode($message?->params?->state, false);
+                $state->moveDetected = 1;
+
+                $device->update([
+                    'error' => $this->prepareErrorReporting($state),
+                    'configuration' => $this->updateConfiguration($state)
+                ]);
+
+                $state->moveDetected = 0;
+                $device->update([
+                    'configuration' => $this->updateConfiguration($state)
+                ]);
+            },
+            sprintf('/sys/%s/%s/thing/event/pet_detect/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+
+                $state = json_decode($message?->params?->state, false);
+                $state->petDetected = 1;
+
+                $device->update([
+                    'error' => $this->prepareErrorReporting($state),
+                    'configuration' => $this->updateConfiguration($state)
+                ]);
+
+                $state->petDetected = 0;
+                $device->update([
+                    'configuration' => $this->updateConfiguration($state)
+                ]);
+
+            },
+            sprintf('/sys/%s/%s/thing/event/pet_in/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+                $configuration = $this->configurationDefinition();
+                $configuration->petDetected = true;
+
+                $device->update([
+                    'configuration' => $configuration->toArray()
+                ]);
+            },
+            sprintf('/sys/%s/%s/thing/event/pet_out/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+                $configuration = $this->configurationDefinition();
+                $configuration->petDetected = false;
+
+                $device->update([
+                    'configuration' => $configuration->toArray()
+                ]);
+            },
+            sprintf('/sys/%s/%s/thing/event/work_start/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+                $state = json_decode($message?->params?->state, false);
+
+                $device->update([
+                    'error' => $this->prepareErrorReporting($state),
+                    'configuration' => $this->updateConfiguration($state)
+                ]);
+            },
+            sprintf('/sys/%s/%s/thing/event/light_over/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+                $state = json_decode($message?->params?->state, false);
+
+                $conf = $this->updateConfiguration($state, ['lightning' => isset($state->lightState)]);
+
+                $device->update([
+                    'configuration' => $conf
+                ]);
+            },
+            sprintf('/sys/%s/%s/thing/event/clean_over/post', $this->device->productKey(), $this->device->deviceName()) => function (Device $device, string $topic, \stdClass|null $message) {
+                $state = json_decode($message?->params?->state, false);
+
+                $device->update([
+                    'error' => $this->prepareErrorReporting($state),
+                    'configuration' => $this->updateConfiguration($state)
+                ]);
+            },
+        ];
+    }
+
+    private function reply(string $topic, ?\stdClass $message)
+    {
+        $generic = GenericReply::reply($topic, $message);
+        MQTT::connection('publisher')->publish($generic->getTopic(), $generic->getMessage());
+    }
+
+    public function getDevice(): Device
+    {
+        return $this->device;
+    }
+
+    public function hasAction(string $action): bool
+    {
+        $hasAction = in_array($action, $this->actions);
+        if ($this->device->proxy_mode == 1) {
+            return false;
+        }
+        switch ($action) {
+            case DeviceActions::START_CLEAN:
+            case DeviceActions::DEODORIZE:
+            case DeviceActions::LEVEL:
+                return $hasAction && $this->device->working_state === DeviceStates::IDLE->value;
+
+            case DeviceActions::START_LIGHTNING:
+                return $hasAction && !($this->device->configuration['states']['lightning'] ?? false);
+
+            case DeviceActions::STOP_LIGHTNING:
+                return $hasAction && ($this->device->configuration['states']['lightning'] ?? false);
+        }
+
+        return $hasAction;
+    }
+
+    public function takeSnapshot(Device $record): void
+    {
+        TakeSnapshot::dispatchSync($record);
+    }
+
+    public function configurationDefinition(): ConfigurationInterface
+    {
+        return Configuration\PetkitT5::fromDevice($this->getDevice());
+    }
+
+    public function configuration()
+    {
+        return $this->configurationDefinition()->toArray();
+    }
+
+    public function propertyChange(Device $device): void
+    {
+        $scheduleChange = false;
+        $difference = JsonHelper::difference($device->configuration['settings'], $device->getOriginal('configuration')['settings']);
+        if (empty($difference)) {
+            $difference = JsonHelper::difference($device->configuration['schedule'], $device->getOriginal('configuration')['schedule']);
+            $scheduleChange = !empty($difference);
+        }
+
+        $dto = $this->configurationDefinition();
+
+        if (!$scheduleChange) {
+            foreach ($difference as $key => $val) {
+                $value = $dto->$key;
+
+                if ($value instanceof PetkitDTOInterface) {
+                    $difference[$key] = $value->toPetkitConfiguration();
+                } else if (is_numeric($value)) {
+                    $difference[$key] = (int)$value;
+                } else if (is_bool($value)) {
+                    $difference[$key] = (int)$value;
+                }
+            }
+            SetProperty::dispatchSync($device, $difference);
+        } else {
+
+            SetProperty::dispatchSync($device, [
+                'feed' => $this->toFeed($device)
+            ]);
+        }
+
+    }
+
+    public function toFeed(Device $device): string
+    {
+
+        $latest = Time::calculateLatest($device->configuration['schedule']);
+        $nextTick = last($latest);
+
+        return json_encode([
+            'schedule' => $device->configuration['schedule'],
+            'nextTick' => $nextTick['t'],
+            'latest' => $latest
+        ]);
+
+
+    }
+
+    public function toHomeassistant()
+    {
+        $data = $this->configurationDefinition()->toArray();
+
+        foreach (['moveDetected', 'petDetected', 'lightning'] as $state) {
+            if (array_key_exists($state, $data['states'])) {
+                $data['states'][$state] = (int)$data['states'][$state];
+            }
+        }
+
+        // MultiRange configs are not exposed to Home Assistant - strip them from the base json.
+        $data['settings'] = array_filter(
+            $data['settings'],
+            fn (string $key) => !Str::contains($key, 'MultiRange'),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        return json_encode($data);
+    }
+
+    public function toSnapshot(): ?string
+    {
+        return $this->configurationDefinition()->toSnapshot();
+    }
+
+    #[HomeassistantTopic(topic: 'setting/set')]
+    public function settings(\stdClass $message)
+    {
+        $configuration = $this->configurationDefinition();
+        $keys = get_object_vars($message);
+
+        foreach ($keys as $attributeName => $value) {
+            $configuration->$attributeName = $value;
+        }
+        $this->getDevice()->update(['configuration' => $configuration]);
+    }
+
+    #[HomeassistantTopic('action/start')]
+    public function action(\stdClass $message): void
+    {
+        $action = $message->action;
+        switch ($action) {
+            case 'start_cleaning':
+                $this->startCleaning($this->getDevice());
+                break;
+            case 'snapshot':
+                $this->takeSnapshot($this->getDevice());
+                break;
+            case 'deodorize':
+                $this->deodorize($this->getDevice());
+                break;
+            case 'level':
+                $this->level($this->getDevice());
+                break;
+            case 'start_lightning':
+                $this->startLightning($this->getDevice());
+                break;
+            case 'stop_lightning':
+                $this->stopLightning($this->getDevice());
+                break;
+        }
+    }
+
+    public function resetWorkingState(Device $record): void
+    {
+        $configuration = $this->configurationDefinition();
+        $configuration->lightning = false;
+
+        $record->update([
+            'working_state' => DeviceStates::IDLE->value,
+            'configuration' => $configuration->toArray()
+        ]);
+    }
+
+    public function startCleaning(Device $record): void
+    {
+        ServiceStart::dispatchSync($record, 0);
+    }
+
+    public function deodorize(Device $record): void
+    {
+        ServiceStart::dispatchSync($record, 2);
+    }
+
+    public function level(Device $record): void
+    {
+        ServiceStart::dispatchSync($record, 4);
+    }
+
+    public function startLightning(Device $record): void
+    {
+        ServiceStart::dispatchSync($record, 7);
+    }
+
+    public function stopLightning(Device $record): void
+    {
+        ServiceEnd::dispatchSync($record, 7);
+    }
+
+    public function toOTA(): array
+    {
+        return [
+
+        ];
+    }
+
+    public function toDevSignup(): array
+    {
+        $config = $this->device->configuration['settings'];
+
+        return [
+            'id' => $this->device->petkit_id,
+            'mac' => $this->device->mac,
+            'sn' => $this->device->serial_number,
+            'secret' => $this->device->secret ?? '',
+            'timezone' => $this->device->timezone,
+            'locale' => $this->device->locale,
+            'shareOpen' => (int)$config['shareOpen'],
+            'typeCode' => (int)$config['typeCode'] ?? 0
+        ];
+    }
+
+    public function toDeviceInfo(): array
+    {
+        $config = $this->device->configuration['settings'];
+        $capacity = $this->device->configuration['capacity'];
+
+        return [
+            'id' => $this->device->petkit_id,
+            'mac' => $this->device->mac,
+            'sn' => $this->device->serial_number,
+            'secret' => $this->device->secret ?? '',
+            'timezone' => $this->device->timezone,
+            'signupAt' => $this->device->created_at->format('Y-m-d\TH:i:s.v\+0000'),
+            'locale' => $this->device->locale,
+            'shareOpen' => (int)$config['shareOpen'],
+            'autoUpgrade' => (int)$config['autoUpgrade'],
+            'modelCode' => 0,
+            'familyId' => 0,
+            'btMac' => $this->device->bt_mac,
+            'typeCode' => (int)$config['typeCode'],
+            'settings' => [
+                'manualLock' => (int)$config['manualLock'],
+                'clickOkEnable' => (int)$config['clickOkEnable'],
+                'lightMode' => (int)$config['lightMode'],
+                'timeDisplay' => (int)$config['timeDisplay'],
+                'camera' => (int)$config['camera'],
+                'microphone' => (int)$config['microphone'],
+                'night' => (int)$config['night'],
+                'cameraLight' => (int)$config['cameraLight'],
+                'toiletLight' => (int)$config['toiletLight'],
+                'preLive' => (int)$config['preLive'],
+                'lightAssist' => (int)$config['lightAssist'],
+                'moveDetection' => (int)$config['moveDetection'],
+                'moveSensitivity' => (int)$config['moveSensitivity'],
+                'petDetection' => (int)$config['petDetection'],
+                'petSensitivity' => (int)$config['petSensitivity'],
+                'toiletDetection' => (int)$config['toiletDetection'],
+                'phDetection' => (int)$config['phDetection'],
+                'detectInterval' => (int)$config['detectInterval'],
+                'autoWork' => (int)$config['autoWork'],
+                'autoIntervalMin' => (int)$config['autoIntervalMin'],
+                'fixedTimeClear' => (int)$config['fixedTimeClear'],
+                'avoidRepeat' => (int)$config['avoidRepeat'],
+                'underweight' => (int)$config['underweight'],
+                'kitten' => (int)$config['kitten'],
+                'bury' => (int)$config['bury'],
+                'deepClean' => (int)$config['deepClean'],
+                'downpos' => (int)$config['downpos'],
+                'sandSaving' => (int)$config['sandSaving'],
+                'sandType' => (int)$config['sandType'],
+                'unit' => (int)$config['unit'],
+                'stillTime' => (int)$config['stillTime'],
+                'lightest' => (int)$config['lightest'],
+                'softMode' => (int)$config['softMode'],
+                'autoSpray' => (int)$config['autoSpray'],
+                'deepSpray' => (int)$config['deepSpray'],
+                'fixedTimeSpray' => (int)$config['fixedTimeSpray'],
+                'sprayDays' => (int)$config['sprayDays'],
+                'disturbMode' => (int)$config['disturbMode'],
+                'toneMode' => (int)$config['toneMode'],
+                'soundEnable' => (int)$config['soundEnable'],
+                'systemSoundEnable' => (int)$config['systemSoundEnable'],
+                'volume' => (int)$config['volume'],
+                'selectedSound' => (int)$config['selectedSound'],
+                'voice' => (int)$config['voice'],
+                'upload' => (int)$config['upload'],
+            ],
+            'userId' => '1',
+            'multiConfig' => $config['multiConfig'],
+            'capacity' => $capacity,
+            'cloudProduct' => [],
+            'serviceStatus' => $config['serviceStatus'],
+            'hertz' => $config['hertz']
+        ];
+    }
+
+    public function toDeviceMultiConfig(): array
+    {
+        return [
+            "detectMultiRange" => json_encode([
+                "detectMultiRange" => [[0, 1440]]
+            ]),
+            "toneMultiRange" => json_encode([
+                "toneMultiRange" => [[1320, 360]]
+            ]),
+            "lightMultiRange" => json_encode([
+                "lightMultiRange" => [[0, 1440]]
+            ])
+        ];
+    }
+
+    public function toFeedGet(): array
+    {
+        $unusedDays = [1, 2, 3, 4, 5, 6, 7];
+        $latest = Time::calculateLatest($this->device->configuration['schedule']);
+        $nextTick = last($latest);
+        $schedules = $this->device->configuration['schedule'];
+
+        foreach ($schedules as &$schedule) {
+            $schedule['itemJsonString'] = json_encode($schedule['it']);
+
+            foreach (explode(',', $schedule['re']) as $re) {
+                unset($unusedDays[intval($re) - 1]);
+            }
+
+        }
+
+        if (!empty($unusedDays)) {
+            $schedules[] = [
+                're' => implode(',', $unusedDays),
+                'it' => [],
+                'itemJsonString' => '[]',
+            ];
+        }
+
+
+        return [
+            'schedule' => $schedules,
+            'nextTick' => $nextTick['t'],
+            'latest' => $latest
+        ];
+    }
+
+    private function updateConfiguration(mixed $content, array $extra = []): array
+    {
+
+        $settings = $this->getDevice()->configuration();
+
+        try {
+
+            //IP - reported inside the `other` string, key/value may or may not be quoted (e.g. Ip:"x.x.x.x" or "Ip":x.x.x.x)
+            $pattern = '/(?:^|,)Ip:\\\\?"(\d{1,3}(?:\.\d{1,3}){3})\\\\?"/';
+            $match = Str::of($content->other)->match($pattern);
+
+            if ($match->value() !== null) {
+                $settings->ipAddress = $match->value();
+            }
+
+            foreach ($extra as $property => $value) {
+                $settings->$property = $value;
+            }
+
+            return $settings->toArray();
+        } catch (\Throwable $exception) {
+            Log::error('T5 Update', [
+                'msg' => $exception->getMessage(),
+            ]);
+        }
+
+        return $settings->toArray();
+    }
+
+    private function prepareErrorReporting(mixed $state)
+    {
+        $error = null;
+
+        if ($state?->door == 0) {
+            $error = 'door_closed';
+        }
+
+        return $error;
+    }
+
+    public function btConnect(BluetoothDevice $btDevice): void
+    {
+        ServiceConnect::dispatchSync(
+            $this->getDevice(), $btDevice,
+        );
+
+    }
+}

--- a/app/Petkit/UI/PetkitT5.php
+++ b/app/Petkit/UI/PetkitT5.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Petkit\UI;
+
+use App\Management\Go2RTC;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\HtmlString;
+use Filament\Forms;
+
+class PetkitT5
+{
+
+    public function formFields(): array
+    {
+        return [
+            Forms\Components\Section::make('Media')->schema([
+                Forms\Components\View::make('camera_stream')->viewData(fn($record): array => [
+                    'streams' => app(Go2RTC::class)->streamUrls($record)
+                ])
+                    ->hidden(fn($record) => is_null($record->configuration()->ipAddress))
+                    ->columnSpan('full'),
+
+                Forms\Components\Placeholder::make('Snapshot')
+                    ->content(function ($record) {
+                        $image = $record->configuration()->lastSnapshot;
+                        if (is_null($image)) {
+                            return '';
+                        }
+                        $blob = Storage::disk('snapshots')->get($image);
+                        if (is_null($blob)) {
+                            return '';
+                        }
+                        return new HtmlString(sprintf('<img src="data:image/jpeg;base64,%s" />', base64_encode($blob)));
+                    })
+                    ->hidden(fn($record) => is_null($record->configuration()->lastSnapshot))
+            ])->collapsible()
+                ->hidden(fn($record) => is_null($record->configuration()->ipAddress) || !$record->mqtt_connected),
+
+            Forms\Components\Section::make('Camera Settings')->columns(2)->schema([
+                Forms\Components\Toggle::make('configuration.settings.camera')
+                    ->helperText('No video footage will be generated if you turn this feature off, but autop cleaning will still work')
+                    ->label('Camera Switch'),
+
+                Forms\Components\Toggle::make('configuration.settings.microphone')
+                    ->helperText('Enable/Disable sound collection')
+                    ->label('Microphone'),
+
+                Forms\Components\Toggle::make('configuration.settings.night')
+                    ->helperText('Enable infrared night vision in dark environment')
+                    ->label('Night Vision'),
+
+                Forms\Components\Toggle::make('configuration.settings.timeDisplay')
+                    ->label('Timestamp Display'),
+
+                Forms\Components\Toggle::make('configuration.settings.cameraLight')
+                    ->label('Camera Light'),
+
+                Forms\Components\Toggle::make('configuration.settings.toiletLight')
+                    ->label('Toilet Light'),
+
+                Forms\Components\Toggle::make('configuration.settings.tumbling')
+                    ->helperText('Sets the Tumbling for Camera')
+                    ->label('Tumbling'),
+
+            ]),
+
+            Forms\Components\Section::make('Smart Detection')->columns(2)->schema([
+                Forms\Components\Toggle::make('configuration.settings.petDetection')
+                    ->helperText('For auto detection of pet movement')
+                    ->label('Pet Appearance Detection'),
+
+                Forms\Components\Select::make('configuration.settings.petSensitivity')
+                    ->helperText('Sensitivity for pet appearance detection')
+                    ->label('Pet Appearance Sensitivity')
+                    ->options([
+                        0 => 0,
+                        1 => 1,
+                        2 => 2,
+                        3 => 3,
+                        4 => 4,
+                        5 => 5,
+                        6 => 6,
+                        7 => 7,
+                        8 => 8,
+                        9 => 9,
+                    ]),
+
+                Forms\Components\Toggle::make('configuration.settings.toiletDetection')
+                    ->helperText('For videos of pet toileting')
+                    ->label('Toilet Video Recording'),
+
+                Forms\Components\Toggle::make('configuration.settings.moveDetection')
+                    ->helperText('For events of movement before the camera')
+                    ->label('Move Detection'),
+
+                Forms\Components\Select::make('configuration.settings.moveSensitivity')
+                    ->helperText('Sensitivity for movement events before the camera')
+                    ->label('Move Sensitivity')
+                    ->options([
+                        0 => 0,
+                        1 => 1,
+                        2 => 2,
+                        3 => 3,
+                        4 => 4,
+                        5 => 5,
+                        6 => 6,
+                        7 => 7,
+                        8 => 8,
+                        9 => 9,
+                    ]),
+            ]),
+
+            Forms\Components\Section::make('Cleaning')->columns(2)->schema([
+
+                Forms\Components\Toggle::make('configuration.settings.kitten')
+                    ->helperText('Disable auto and periodical cleaning')
+                    ->label('Kitten Protection'),
+
+                Forms\Components\Toggle::make('configuration.settings.autoWork')
+                    ->helperText('After the pet leaves, the device starts automatic cleaning')
+                    ->label('Auto Cleaning'),
+
+                Forms\Components\Select::make('configuration.settings.stillTime')
+                    ->label('Delayed Cleaning')
+                    ->helperText('Set time interval before device starts cleaning')
+                    ->options([
+                        120 => '2 Minutes',
+                        1200 => '20 Minutes',
+                        1800 => '30 Minutes',
+                        2400 => '40 Minutes',
+                        3000 => '50 Minutes',
+                        3600 => '60 Minutes',
+                    ]),
+
+                Forms\Components\Toggle::make('configuration.settings.avoidRepeat')
+                    ->helperText('Avoid repeated cleaning within a short period')
+                    ->label('Avoid Repeated Cleaning'),
+
+                Forms\Components\Toggle::make('configuration.settings.sandSaving')
+                    ->helperText('Reduce litter usage during automatic cleaning')
+                    ->label('Litter Saving'),
+            ]),
+
+            Forms\Components\Section::make('Deodorize')->columns(2)->schema([
+                Forms\Components\Toggle::make('configuration.settings.autoSpray')
+                    ->helperText('Auto-deodorize after pet use or before cleaning')
+                    ->label('Auto Deodorizing'),
+
+                Forms\Components\Toggle::make('configuration.settings.deepSpray')
+                    ->helperText('The device will deodorize twice consecutively each time')
+                    ->label('Deep Deodorizing'),
+
+                Forms\Components\TextInput::make('configuration.settings.sprayDays')
+                    ->helperText('Deodorant cartridge refill cycle in days')
+                    ->label('Deodorant Refill Cycle')
+                    ->numeric(),
+            ]),
+
+            Forms\Components\Section::make('Lights')->columns(2)->schema([
+                Forms\Components\Toggle::make('configuration.settings.lightAssist')
+                    ->helperText('Turns on the light to assist cleaning/toileting playback in low light')
+                    ->label('Light Assist for Cleaning'),
+            ]),
+
+            Forms\Components\Section::make('General')->columns(2)->schema([
+                Forms\Components\Toggle::make('configuration.settings.manualLock')
+                    ->helperText('Activate the child lock to disable the control panel')
+                    ->label('Child Lock'),
+
+                Forms\Components\Toggle::make('configuration.settings.clickOkEnable')
+                    ->helperText('Play a confirmation sound on button press')
+                    ->label('Confirm Click Sound'),
+            ]),
+
+            Forms\Components\Section::make('Health Monitoring')->columns(2)->schema([
+                Forms\Components\Toggle::make('configuration.settings.voice')
+                    ->helperText('Health monitoring for voice')
+                    ->label('Yowling Detection'),
+
+                Forms\Components\Toggle::make('configuration.settings.phDetection')
+                    ->helperText('Urine pH detection/measurement on/off')
+                    ->label('Urine pH Detection'),
+
+                Forms\Components\Toggle::make('configuration.settings.softMode')
+                    ->label('Loose Stool Recognition'),
+            ]),
+
+        ];
+    }
+}


### PR DESCRIPTION
Field set and wire/file key mapping reverse engineered from the ctrl_t5 MIPS firmware and its app_conf dump (t5.conf): confirmed struct offsets in the local file parser and the remote property_set dispatcher for all settings, including the timestamp_enable->timeDisplay rename and the night/infrared alias. Adds Configuration, DeviceDefinition and Filament UI classes mirroring the existing T7 (PuroBot Crystal) implementation, and registers the t5 device_type in Device.php and DeviceResource.php.