### PR TITLE
Fix/timezone/configurable

### DIFF
--- a/app/Filament/Widgets/PetEventCountsWidget.php
+++ b/app/Filament/Widgets/PetEventCountsWidget.php
@@ -33,7 +33,7 @@ class PetEventCountsWidget extends Widget
             ->where('created_at', '>=', $since)
             ->with('pet:id,name')
             ->get()
-            ->groupBy(fn (History $history) => $history->created_at->timezone('Europe/Berlin')->toDateString())
+            ->groupBy(fn (History $history) => $history->created_at->timezone(config('app.timezone'))->toDateString())
             ->sortKeysDesc()
             ->map(fn (Collection $dayHistories) => $dayHistories
                 ->groupBy('pet_id')

--- a/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
+++ b/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
@@ -62,11 +62,45 @@
             text-transform: uppercase;
             color: var(--gray-400);
         }
+        @keyframes petkit-spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+        .petkit-refreshed {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.75rem;
+            color: var(--gray-400);
+        }
+        .petkit-refreshed__text {
+            font-variant-numeric: tabular-nums;
+            white-space: nowrap;
+        }
+        .petkit-spinning svg {
+            transform-origin: center;
+            animation: petkit-spin 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+        }
     </style>
 
     @if ($histories->isEmpty())
         <x-filament::section>
             <x-slot name="heading">{{ $this->record->name ?? $this->record->serial_number }}</x-slot>
+            <x-slot name="afterHeader">
+                <div class="petkit-refreshed">
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <x-filament::icon-button
+                        icon="heroicon-m-arrow-path"
+                        color="gray"
+                        size="sm"
+                        label="Refresh"
+                        wire:click="$refresh"
+                        x-data="{ spinning: false }"
+                        x-on:click="spinning = true; setTimeout(() => spinning = false, 600)"
+                        x-bind:class="{ 'petkit-spinning': spinning }"
+                    />
+                </div>
+            </x-slot>
 
             <div style="text-align:center;padding:1.5rem 0;color:var(--gray-500);font-size:0.875rem;">
                 {{ __('No activities recorded yet.') }}
@@ -75,6 +109,21 @@
     @else
         <x-filament::section>
             <x-slot name="heading">{{ $this->record->name ?? $this->record->serial_number }}</x-slot>
+            <x-slot name="afterHeader">
+                <div class="petkit-refreshed">
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <x-filament::icon-button
+                        icon="heroicon-m-arrow-path"
+                        color="gray"
+                        size="sm"
+                        label="Refresh"
+                        wire:click="$refresh"
+                        x-data="{ spinning: false }"
+                        x-on:click="spinning = true; setTimeout(() => spinning = false, 600)"
+                        x-bind:class="{ 'petkit-spinning': spinning }"
+                    />
+                </div>
+            </x-slot>
 
             <div class="petkit-timeline">
                 @php($lastDate = null)

--- a/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
+++ b/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
@@ -79,7 +79,7 @@
             <div class="petkit-timeline">
                 @php($lastDate = null)
                 @foreach ($histories as $history)
-                    @php($eventDate = $history->created_at?->timezone('Europe/Berlin'))
+                    @php($eventDate = $history->created_at?->timezone(config('app.timezone')))
                     @php($dateKey = $eventDate?->toDateString())
                     @if ($dateKey !== $lastDate)
                         <div class="petkit-timeline__day">
@@ -108,7 +108,7 @@
                             </div>
                             <div class="petkit-timeline__desc">{!! $history->message() !!}</div>
                             <div class="petkit-timeline__date">
-                                {{ $history->created_at?->timezone('Europe/Berlin')?->format('F j, Y · H:i') }}
+                                {{ $history->created_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i') }}
                             </div>
 
                             @php($listingMedia = \App\Filament\Resources\DeviceResource\Pages\PetkitActivities::mediaForListing($history->media))

--- a/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
+++ b/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
@@ -88,7 +88,7 @@
             <x-slot name="heading">{{ $this->record->name ?? $this->record->serial_number }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -111,7 +111,7 @@
             <x-slot name="heading">{{ $this->record->name ?? $this->record->serial_number }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -157,7 +157,7 @@
                             </div>
                             <div class="petkit-timeline__desc">{!! $history->message() !!}</div>
                             <div class="petkit-timeline__date">
-                                {{ $history->created_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i') }}
+                                {{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}
                             </div>
 
                             @php($listingMedia = \App\Filament\Resources\DeviceResource\Pages\PetkitActivities::mediaForListing($history->media))

--- a/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
+++ b/resources/views/filament/resources/device-resource/pages/petkit-activities.blade.php
@@ -88,7 +88,7 @@
             <x-slot name="heading">{{ $this->record->name ?? $this->record->serial_number }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('dddd, LL · LTS (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -111,7 +111,7 @@
             <x-slot name="heading">{{ $this->record->name ?? $this->record->serial_number }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('dddd, LL · LTS (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -157,7 +157,7 @@
                             </div>
                             <div class="petkit-timeline__desc">{!! $history->message() !!}</div>
                             <div class="petkit-timeline__date">
-                                {{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}
+                                {{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LL · LT') }}
                             </div>
 
                             @php($listingMedia = \App\Filament\Resources\DeviceResource\Pages\PetkitActivities::mediaForListing($history->media))

--- a/resources/views/filament/resources/device-resource/pages/petkit-activity-detail.blade.php
+++ b/resources/views/filament/resources/device-resource/pages/petkit-activity-detail.blade.php
@@ -88,11 +88,11 @@
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Started</div>
-            <div class="petkit-detail__value">{{ $history->created_at?->timezone('Europe/Berlin')?->format('F j, Y · H:i:s') }}</div>
+            <div class="petkit-detail__value">{{ $history->created_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i:s') }}</div>
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Last updated</div>
-            <div class="petkit-detail__value">{{ $history->updated_at?->timezone('Europe/Berlin')?->format('F j, Y · H:i:s') }}</div>
+            <div class="petkit-detail__value">{{ $history->updated_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i:s') }}</div>
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Duration</div>
@@ -174,8 +174,8 @@
                                                     @foreach ($clip->segments as $segment)
                                                         <tr>
                                                             <td><code>{{ $segment['fileId'] ?? '—' }}</code></td>
-                                                            <td>{{ isset($segment['startTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['startTime'])->timezone('Europe/Berlin')->format('H:i:s') : '—' }}</td>
-                                                            <td>{{ isset($segment['endTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['endTime'])->timezone('Europe/Berlin')->format('H:i:s') : '—' }}</td>
+                                                            <td>{{ isset($segment['startTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['startTime'])->timezone(config('app.timezone'))->format('H:i:s') : '—' }}</td>
+                                                            <td>{{ isset($segment['endTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['endTime'])->timezone(config('app.timezone'))->format('H:i:s') : '—' }}</td>
                                                             <td>{{ isset($segment['duration']) ? number_format($segment['duration'] / 1000, 1) . 's' : '—' }}</td>
                                                             <td>{{ $this->formatBytes($segment['size'] ?? null) }}</td>
                                                         </tr>

--- a/resources/views/filament/resources/device-resource/pages/petkit-activity-detail.blade.php
+++ b/resources/views/filament/resources/device-resource/pages/petkit-activity-detail.blade.php
@@ -88,11 +88,11 @@
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Started</div>
-            <div class="petkit-detail__value">{{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}</div>
+            <div class="petkit-detail__value">{{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LL · LTS') }}</div>
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Last updated</div>
-            <div class="petkit-detail__value">{{ $history->updated_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}</div>
+            <div class="petkit-detail__value">{{ $history->updated_at?->timezone(config('app.timezone'))?->isoFormat('LL · LTS') }}</div>
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Duration</div>

--- a/resources/views/filament/resources/device-resource/pages/petkit-activity-detail.blade.php
+++ b/resources/views/filament/resources/device-resource/pages/petkit-activity-detail.blade.php
@@ -88,11 +88,11 @@
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Started</div>
-            <div class="petkit-detail__value">{{ $history->created_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i:s') }}</div>
+            <div class="petkit-detail__value">{{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}</div>
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Last updated</div>
-            <div class="petkit-detail__value">{{ $history->updated_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i:s') }}</div>
+            <div class="petkit-detail__value">{{ $history->updated_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}</div>
         </div>
         <div class="petkit-detail__row">
             <div class="petkit-detail__label">Duration</div>
@@ -174,8 +174,8 @@
                                                     @foreach ($clip->segments as $segment)
                                                         <tr>
                                                             <td><code>{{ $segment['fileId'] ?? '—' }}</code></td>
-                                                            <td>{{ isset($segment['startTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['startTime'])->timezone(config('app.timezone'))->format('H:i:s') : '—' }}</td>
-                                                            <td>{{ isset($segment['endTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['endTime'])->timezone(config('app.timezone'))->format('H:i:s') : '—' }}</td>
+                                                            <td>{{ isset($segment['startTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['startTime'])->timezone(config('app.timezone'))->isoFormat('LTS') : '—' }}</td>
+                                                            <td>{{ isset($segment['endTime']) ? \Illuminate\Support\Carbon::createFromTimestamp($segment['endTime'])->timezone(config('app.timezone'))->isoFormat('LTS') : '—' }}</td>
                                                             <td>{{ isset($segment['duration']) ? number_format($segment['duration'] / 1000, 1) . 's' : '—' }}</td>
                                                             <td>{{ $this->formatBytes($segment['size'] ?? null) }}</td>
                                                         </tr>

--- a/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
+++ b/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
@@ -86,7 +86,7 @@
             <x-slot name="heading">{{ $this->record->name }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -109,7 +109,7 @@
             <x-slot name="heading">{{ $this->record->name }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -150,7 +150,7 @@
                             </div>
                             <div class="petkit-timeline__desc">{!! $history->message() !!}</div>
                             <div class="petkit-timeline__date">
-                                {{ $history->created_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i') }}
+                                {{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}
                             </div>
 
                             @php($listingMedia = \App\Filament\Resources\DeviceResource\Pages\PetkitActivities::mediaForListing($history->media))

--- a/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
+++ b/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
@@ -60,11 +60,45 @@
             text-transform: uppercase;
             color: var(--gray-400);
         }
+        @keyframes petkit-spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+        .petkit-refreshed {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.75rem;
+            color: var(--gray-400);
+        }
+        .petkit-refreshed__text {
+            font-variant-numeric: tabular-nums;
+            white-space: nowrap;
+        }
+        .petkit-spinning svg {
+            transform-origin: center;
+            animation: petkit-spin 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+        }
     </style>
 
     @if ($histories->isEmpty())
         <x-filament::section>
             <x-slot name="heading">{{ $this->record->name }}</x-slot>
+            <x-slot name="afterHeader">
+                <div class="petkit-refreshed">
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <x-filament::icon-button
+                        icon="heroicon-m-arrow-path"
+                        color="gray"
+                        size="sm"
+                        label="Refresh"
+                        wire:click="$refresh"
+                        x-data="{ spinning: false }"
+                        x-on:click="spinning = true; setTimeout(() => spinning = false, 600)"
+                        x-bind:class="{ 'petkit-spinning': spinning }"
+                    />
+                </div>
+            </x-slot>
 
             <div style="text-align:center;padding:1.5rem 0;color:var(--gray-500);font-size:0.875rem;">
                 {{ __('No activities recorded yet.') }}
@@ -73,6 +107,21 @@
     @else
         <x-filament::section>
             <x-slot name="heading">{{ $this->record->name }}</x-slot>
+            <x-slot name="afterHeader">
+                <div class="petkit-refreshed">
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->format('l, F j, Y · H:i:s (T)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->format('H:i:s') }}</span>
+                    <x-filament::icon-button
+                        icon="heroicon-m-arrow-path"
+                        color="gray"
+                        size="sm"
+                        label="Refresh"
+                        wire:click="$refresh"
+                        x-data="{ spinning: false }"
+                        x-on:click="spinning = true; setTimeout(() => spinning = false, 600)"
+                        x-bind:class="{ 'petkit-spinning': spinning }"
+                    />
+                </div>
+            </x-slot>
 
             <div class="petkit-timeline">
                 @php($lastDate = null)

--- a/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
+++ b/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
@@ -77,7 +77,7 @@
             <div class="petkit-timeline">
                 @php($lastDate = null)
                 @foreach ($histories as $history)
-                    @php($eventDate = $history->created_at?->timezone('Europe/Berlin'))
+                    @php($eventDate = $history->created_at?->timezone(config('app.timezone')))
                     @php($dateKey = $eventDate?->toDateString())
                     @if ($dateKey !== $lastDate)
                         <div class="petkit-timeline__day">
@@ -101,7 +101,7 @@
                             </div>
                             <div class="petkit-timeline__desc">{!! $history->message() !!}</div>
                             <div class="petkit-timeline__date">
-                                {{ $history->created_at?->timezone('Europe/Berlin')?->format('F j, Y · H:i') }}
+                                {{ $history->created_at?->timezone(config('app.timezone'))?->format('F j, Y · H:i') }}
                             </div>
 
                             @php($listingMedia = \App\Filament\Resources\DeviceResource\Pages\PetkitActivities::mediaForListing($history->media))

--- a/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
+++ b/resources/views/filament/resources/pet-resource/pages/pet-activities.blade.php
@@ -86,7 +86,7 @@
             <x-slot name="heading">{{ $this->record->name }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-empty-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('dddd, LL · LTS (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -109,7 +109,7 @@
             <x-slot name="heading">{{ $this->record->name }}</x-slot>
             <x-slot name="afterHeader">
                 <div class="petkit-refreshed">
-                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('LLLL (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
+                    <span class="petkit-refreshed__text" wire:key="refreshed-at-{{ now()->format('His') }}" title="{{ now()->timezone(config('app.timezone'))->isoFormat('dddd, LL · LTS (z)') }}">Last refreshed {{ now()->timezone(config('app.timezone'))->isoFormat('LTS') }}</span>
                     <x-filament::icon-button
                         icon="heroicon-m-arrow-path"
                         color="gray"
@@ -150,7 +150,7 @@
                             </div>
                             <div class="petkit-timeline__desc">{!! $history->message() !!}</div>
                             <div class="petkit-timeline__date">
-                                {{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LLL') }}
+                                {{ $history->created_at?->timezone(config('app.timezone'))?->isoFormat('LL · LT') }}
                             </div>
 
                             @php($listingMedia = \App\Filament\Resources\DeviceResource\Pages\PetkitActivities::mediaForListing($history->media))

--- a/resources/views/filament/widgets/pet-event-counts.blade.php
+++ b/resources/views/filament/widgets/pet-event-counts.blade.php
@@ -20,7 +20,7 @@
 
     <x-filament::section heading="Pet Activity by Day">
         @forelse ($dailyCounts as $date => $pets)
-            @php($day = \Illuminate\Support\Carbon::parse($date, 'Europe/Berlin'))
+            @php($day = \Illuminate\Support\Carbon::parse($date, config('app.timezone')))
             <div class="petkit-counts__day">
                 <div class="petkit-counts__date">
                     {{ $day->isToday() ? __('Today') : ($day->isYesterday() ? __('Yesterday') : $day->translatedFormat('l, F j, Y')) }}

--- a/resources/views/filament/widgets/recent-activity.blade.php
+++ b/resources/views/filament/widgets/recent-activity.blade.php
@@ -63,7 +63,7 @@
                                 <div class="petkit-recent__meta">
                                     {{ $history->pet?->name ?? $history->device?->name ?? $history->device?->serial_number ?? __('petkit.unknown') }}
                                     &middot;
-                                    {{ $history->created_at?->timezone('Europe/Berlin')?->diffForHumans() }}
+                                    {{ $history->created_at?->timezone(config('app.timezone'))?->diffForHumans() }}
                                 </div>
                                 <div class="petkit-recent__desc">{!! $history->message() !!}</div>
                             </div>


### PR DESCRIPTION
- Fixes bug where timezone was hardcoded rather than respecting the `APP_TIMEZONE` environment var
- Leverage `IntlDateFormatter` to format timestamps by region (12hr vs 24hr)
- Adds a refresh button to the activities pages as well as a timestamp for when it was last loaded
  - Originally added to help me debug a timezone thing but then realized it might be nice for everyday users

Before:
<img width="1160" height="245" alt="image" src="https://github.com/user-attachments/assets/07a29dea-dae4-4017-abac-ac45f4e20fb9" />

<img width="460" height="394" alt="image" src="https://github.com/user-attachments/assets/e3634018-c7f9-4556-9ab3-e03dca1a8bf5" />



After:
<img width="1141" height="233" alt="image" src="https://github.com/user-attachments/assets/46cbf4fd-f7ab-4f56-b051-4bedd7ea7b11" />

<img width="499" height="413" alt="image" src="https://github.com/user-attachments/assets/a0682e6c-3c9b-4c70-b5eb-fdada87eb3dc" />
